### PR TITLE
Add jshinting support

### DIFF
--- a/blueprints/ember-cli-mocha/files/tests/test-helper.js
+++ b/blueprints/ember-cli-mocha/files/tests/test-helper.js
@@ -15,7 +15,11 @@ $(document).ready(function(){
   // This avoids jshint warnings re: `Redefinition of 'expect'`.
   window.expect = chai.expect;
 
-  require('ember-cli/test-loader')['default'].load();
+  var TestLoader = require('ember-cli/test-loader')['default'];
+  TestLoader.prototype.shouldLoadModule = function(moduleName) {
+    return moduleName.match(/[-_]test$/) || moduleName.match(/\.jshint$/);
+  };
+  TestLoader.load();
 
   mocha.run();
 });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var fs = require('fs');
+var jshintTrees = require('broccoli-jshint');
 
 module.exports = {
   name: 'Ember CLI Mocha',
@@ -66,6 +67,7 @@ module.exports = {
         });
       });
     }
+    this.jshintrc = app.options.jshintrc;
   },
 
   contentFor: function(type) {
@@ -76,5 +78,27 @@ module.exports = {
 
   _readTemplate: function(name) {
     return fs.readFileSync(path.join(__dirname, 'templates', name + '.html'));
+  },
+
+  lintTree: function(type, tree) {
+    return jshintTrees(tree, {
+      jshintrcPath: this.jshintrc.tests,
+      description: 'JSHint ' + type + '- Mocha',
+      testGenerator: testGenerator
+    });
   }
+
 };
+
+function testGenerator(relativePath, passed, errors) {
+  if (errors) {
+    errors = "\\n" + this.escapeErrorString(errors);
+  } else {
+    errors = "";
+  }
+
+  return "describe('JSHint - " + relativePath + "', function(){\n" +
+    "it('should pass jshint', function() { \n" +
+    "  expect(" + !!passed + ", '" + relativePath + " should pass jshint." + errors + "').to.be.ok(); \n" +
+    "})});\n";
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "url": "https://github.com/switchfly/ember-cli-mocha/issues"
   },
   "homepage": "https://github.com/switchfly/ember-cli-mocha",
-  "dependencies": { },
+  "dependencies": {
+    "broccoli-jshint": "0.5.3"
+  },
   "bundledDependencies": [ ]
 }


### PR DESCRIPTION
This uses a new ember-cli addon hook to enable jshint test output, just like in the stock qunit setup.