### PR TITLE
Added an integration test blue print

### DIFF
--- a/blueprints/integration-test/files/tests/integration/__name__-test.js
+++ b/blueprints/integration-test/files/tests/integration/__name__-test.js
@@ -1,0 +1,23 @@
+/* jshint expr:true */
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+var App;
+
+describe('Integration: <%= classifiedModuleName %>', function() {
+  beforeEach(function() {
+    App = startApp();
+  });
+
+  afterEach(function() {
+    Ember.run(App, 'destroy');
+  });
+
+  it('can visit /<%= dasherizedModuleName %>', function() {
+    visit('/<%= dasherizedModuleName %>');
+
+    andThen(function() {
+      expect(currentPath()).to.equal('<%= dasherizedModuleName %>');
+    });
+  });
+});

--- a/blueprints/integration-test/index.js
+++ b/blueprints/integration-test/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'Generates an integration test for a feature.'
+};


### PR DESCRIPTION
We at godaddy.com are using integration tests in our suite instead of acceptance tests. I believe others would use the integration name space too. 

Other wise I can pull this blue print into it's own addon. 

Cheers
 