### PR TITLE
Updates to match ember-cli-qunit 0.2.0 and 0.3.0 changes.

### DIFF
--- a/blueprints/ember-cli-mocha/files/tests/test-helper.js
+++ b/blueprints/ember-cli-mocha/files/tests/test-helper.js
@@ -1,25 +1,4 @@
-/* globals require, mocha */
 import resolver from './helpers/resolver';
 import { setResolver } from 'ember-mocha';
 
 setResolver(resolver);
-
-document.write('<div id="ember-testing-container"><div id="ember-testing"></div></div>');
-
-$(document).ready(function(){
-  // Rename elements from qunit -> mocha
-  $('#qunit').attr('id', 'mocha');
-  $('#qunit-fixture').attr('id', 'mocha-fixture');
-
-  // Declare `expect` as a global here instead of as a var in individual tests.
-  // This avoids jshint warnings re: `Redefinition of 'expect'`.
-  window.expect = chai.expect;
-
-  var TestLoader = require('ember-cli/test-loader')['default'];
-  TestLoader.prototype.shouldLoadModule = function(moduleName) {
-    return moduleName.match(/[-_]test$/) || moduleName.match(/\.jshint$/);
-  };
-  TestLoader.load();
-
-  mocha.run();
-});

--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -29,7 +29,7 @@ module.exports = {
         return addonContext.addBowerPackageToProject('ember-cli/ember-cli-test-loader', '0.1.0');
       })
       .then(function() {
-        return addonContext.addBowerPackageToProject('stefanpenner/ember-cli-shims', '0.0.3');
+        return addonContext.addBowerPackageToProject('ember-cli/ember-cli-shims', '0.0.3');
       });
   }
 };

--- a/index.js
+++ b/index.js
@@ -38,8 +38,14 @@ module.exports = {
         app.bowerDirectory + '/mocha/mocha.css',
         app.bowerDirectory + '/chai/chai.js',
         app.bowerDirectory + '/ember-mocha/mocha-setup.js',
-        app.bowerDirectory + '/ember-mocha-adapter/adapter.js'
+        app.bowerDirectory + '/ember-mocha-adapter/adapter.js',
+        'vendor/ember-cli-mocha/test-loader.js'
       ];
+
+      var addonOptions = app.options['ember-cli-mocha'];
+      if (addonOptions && !addonOptions.disableContainerStyles) {
+        fileAssets.push('vendor/ember-cli-mocha/test-container-styles.css');
+      }
 
       app.import(app.bowerDirectory + '/ember-mocha/ember-mocha.amd.js', {
          type: 'test',

--- a/templates/test-body.html
+++ b/templates/test-body.html
@@ -1,2 +1,6 @@
-<div id="qunit"></div>
-<div id="qunit-fixture"></div>
+<div id="mocha"></div>
+<div id="mocha-fixture"></div>
+
+<div id="ember-testing-container">
+  <div id="ember-testing"></div>
+</div>

--- a/vendor/ember-cli-mocha/test-container-styles.css
+++ b/vendor/ember-cli-mocha/test-container-styles.css
@@ -1,0 +1,14 @@
+#ember-testing-container {
+  position: absolute;
+  background: white;
+  bottom: 0;
+  right: 0;
+  width: 640px;
+  height: 384px;
+  overflow: auto;
+  z-index: 9999;
+  border: 1px solid #ccc;
+}
+#ember-testing {
+  zoom: 50%;
+}

--- a/vendor/ember-cli-mocha/test-loader.js
+++ b/vendor/ember-cli-mocha/test-loader.js
@@ -1,0 +1,15 @@
+/* globals jQuery,chai,mocha */
+
+jQuery(document).ready(function() {
+  // Declare `expect` as a global here instead of as a var in individual tests.
+  // This avoids jshint warnings re: `Redefinition of 'expect'`.
+  window.expect = chai.expect;
+
+  var TestLoader = require('ember-cli/test-loader')['default'];
+  TestLoader.prototype.shouldLoadModule = function(moduleName) {
+    return moduleName.match(/[-_]test$/) || moduleName.match(/\.jshint$/);
+  };
+  TestLoader.load();
+
+  mocha.run();
+});


### PR DESCRIPTION
@dgeb - This will still need a quick sanity check/run-through to confirm (no tests and I don't use it normally so can't smoke test easily).

This should make us fully compatible with ember-cli-qunit@0.3.0.