### PR TITLE
Use .jshintrc for the type being linted.

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = {
 
   lintTree: function(type, tree) {
     return jshintTrees(tree, {
-      jshintrcPath: this.jshintrc.tests,
+      jshintrcPath: this.jshintrc[type],
       description: 'JSHint ' + type + '- Mocha',
       testGenerator: testGenerator
     });


### PR DESCRIPTION
Fixes an issue where we were always using `tests/.jshintrc` instead of the type specific one (`.jshintrc` for app and `tests/.jshintrc` for tests).

The same bug was fixed in ember-cli-qunit@0.3.1.