### PR TITLE
Restore ability to filter tests on command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
       var queryString = '';
 
       if (options.filter) {
-        queryString = "?grep=" + options.filter;
+        queryString = "grep=" + options.filter;
       }
 
       return queryString;


### PR DESCRIPTION
ember-cli/ember-cli@ad86fa1 made it possible to include `?hidepassed` in the testem configuration, but broke the ability to pass a filter to ember-cli-mocha via the command line. Without this change, the filter fails because the URL contains `??`.

Is there any interest in a a dummy application for testing ember-cli-mocha? I recognise that it’s mostly a wrapper for ember-mocha so maybe it’s not worth it, but maybe tests would have caught this before the last release. However I see that [ember-cli-qunit doesn’t have tests either](https://github.com/ember-cli/ember-cli-qunit/issues/22), so maybe it’s hard.