### PR TITLE
chaijs 1.10 allows to write lint-friendly tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 

--- a/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModule,
   it
@@ -15,7 +14,7 @@ describeModule(
     // Replace this with your real tests.
     it('exists', function() {
       var adapter = this.subject();
-      expect(adapter).to.be.ok;
+      expect(adapter).to.be.ok();
     });
   }
 );

--- a/blueprints/component-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeComponent,
   it

--- a/blueprints/controller-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/controller-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModule,
   it
@@ -15,7 +14,7 @@ describeModule(
     // Replace this with your real tests.
     it('exists', function() {
       var controller = this.subject();
-      expect(controller).to.be.ok;
+      expect(controller).to.be.ok();
     });
   }
 );

--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   <%= camelizedModuleName %>
 } from '<%= dasherizedPackageName %>/helpers/<%= dasherizedModuleName %>';
@@ -7,6 +6,6 @@ describe('<%= classifiedModuleName %>Helper', function() {
   // Replace this with your real tests.
   it('works', function() {
     var result = <%= camelizedModuleName %>(42);
-    expect(result).to.be.ok;
+    expect(result).to.be.ok();
   });
 });

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import Ember from 'ember';
 import { initialize } from '<%= dasherizedPackageName %>/initializers/<%= dasherizedModuleName %>';
 
@@ -18,6 +17,6 @@ describe('<%= classifiedModuleName %>Initializer', function() {
     initialize(container, application);
 
     // you would normally confirm the results of the initializer here
-    expect(true).to.be.ok;
+    expect(true).to.be.ok();
   });
 });

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import Ember from 'ember';
 import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
 
@@ -7,6 +6,6 @@ describe('<%= classifiedModuleName %>Mixin', function() {
   it('works', function() {
     var <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
     var subject = <%= classifiedModuleName %>Object.create();
-    expect(subject).to.be.ok;
+    expect(subject).to.be.ok();
   });
 });

--- a/blueprints/model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModel,
   it
@@ -16,7 +15,7 @@ describeModel(
     it('exists', function() {
       var model = this.subject();
       // var store = this.store();
-      expect(model).to.be.ok;
+      expect(model).to.be.ok();
     });
   }
 );

--- a/blueprints/route-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModule,
   it
@@ -14,7 +13,7 @@ describeModule(
   function() {
     it('exists', function() {
       var route = this.subject();
-      expect(route).to.be.ok;
+      expect(route).to.be.ok();
     });
   }
 );

--- a/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModule,
   it
@@ -15,7 +14,7 @@ describeModule(
     // Replace this with your real tests.
     it('exists', function() {
       var serializer = this.subject();
-      expect(serializer).to.be.ok;
+      expect(serializer).to.be.ok();
     });
   }
 );

--- a/blueprints/service-test/files/tests/unit/services/__name__-test.js
+++ b/blueprints/service-test/files/tests/unit/services/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModule,
   it
@@ -15,7 +14,7 @@ describeModule(
     // Replace this with your real tests.
     it('exists', function() {
       var service = this.subject();
-      expect(service).to.be.ok;
+      expect(service).to.be.ok();
     });
   }
 );

--- a/blueprints/transform-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModule,
   it
@@ -15,7 +14,7 @@ describeModule(
     // Replace this with your real tests.
     it('exists', function() {
       var transform = this.subject();
-      expect(transform).to.be.ok;
+      expect(transform).to.be.ok();
     });
   }
 );

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.js
@@ -1,10 +1,9 @@
-/* jshint expr:true */
 import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
 
 describe('<%= camelizedModuleName %>', function() {
   // Replace this with your real tests.
   it('works', function() {
     var result = <%= camelizedModuleName %>();
-    expect(result).to.be.ok;
+    expect(result).to.be.ok();
   });
 });

--- a/blueprints/view-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/view-test/files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import {
   describeModule,
   it
@@ -15,7 +14,7 @@ describeModule(
     // Replace this with your real tests.
     it('exists', function() {
       var view = this.subject();
-      expect(view).to.be.ok;
+      expect(view).to.be.ok();
     });
   }
 );


### PR DESCRIPTION
`be.ok;` and others can now be written as `be.ok();`

Fixes https://github.com/switchfly/ember-cli-mocha/issues/6
More details https://github.com/chaijs/chai/pull/297