### PR TITLE
Removed lint-friendly assertion from jshint test generator

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,6 @@ function testGenerator(relativePath, passed, errors) {
 
   return "describe('JSHint - " + relativePath + "', function(){\n" +
     "it('should pass jshint', function() { \n" +
-    "  expect(" + !!passed + ", '" + relativePath + " should pass jshint." + errors + "').to.be.ok(); \n" +
+    "  expect(" + !!passed + ", '" + relativePath + " should pass jshint." + errors + "').to.be.ok; \n" +
     "})});\n";
 }


### PR DESCRIPTION
The ability to call assertions as functions has been [reverted in Chai master](https://github.com/chaijs/chai/pull/306), and is slated to go out in the next release. Additionally, using this lint-friendly syntax is [incompatible with chai-as-promised](https://github.com/domenic/chai-as-promised/issues/74).