### PR TITLE
Added ability to invert the test filter by prepending a '^' char

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,14 @@ module.exports = {
       var queryString = '';
 
       if (options.filter) {
-        queryString = "grep=" + options.filter;
+        // If the filter begins with a hat char (^), invert the grep
+        var exclusionMatch = options.filter.match(/\^(.*)/);
+
+        if (exclusionMatch) {
+          queryString = 'invert=1&grep=' + exclusionMatch[1];
+        } else {
+          queryString = 'grep=' + options.filter;
+        }
       }
 
       return queryString;


### PR DESCRIPTION
The CI tool we use [recently started supporting running concurrent tests](https://codeship.com/features/parallelci), which I really want to take advantage of. The `--filter` option to `ember test` is perfect for running a subset of tests, however the major drawback is that _all_ tests must be grepabble in a mutually exclusive way, which makes it easy for tests to become accidentally excluded from the CI build. A great way to solve this is to use the [`invert` option](https://github.com/mochajs/mocha/pull/481) in mocha (introduced in v1.3) so that one build pipeline can pick up all non-opt-in tests. This is also just useful to be able to do by itself.

Since ember-cli only has plumbing for passing a filter to the `buildTestPageQueryString` hook, the question becomes how to encode the invert flag into the filter (I'm assuming that since test runners don't universally support this behavior, adding an `--invert` option to `ember test` is not viable). The important things I could think of are:

1. Don't conflict with something you actually want to grep for
2. Don't use characters that are interpolated on the command line
3. Use something that is widely accepted as an inversion operation

The best fit I could come up with is prepending the `^` character at the beginning of the filter, since it's unlikely to exist in test description/names, is cli-friendly afaict, and is how you negate regex character classes. The only downside is that it also happens to be how you anchor a regex match to the beginning of the string, possibly giving the false impression that the filter supports regular expressions.

Thoughts?