### PR TITLE
Fix testing root element styles not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
         'vendor/ember-cli-mocha/test-loader.js'
       ];
 
-      var addonOptions = app.options['ember-cli-mocha'];
+      var addonOptions = app.options['ember-cli-mocha'] || {};
       if (addonOptions && !addonOptions.disableContainerStyles) {
         fileAssets.push('vendor/ember-cli-mocha/test-container-styles.css');
       }

--- a/vendor/ember-cli-mocha/test-container-styles.css
+++ b/vendor/ember-cli-mocha/test-container-styles.css
@@ -1,5 +1,5 @@
 #ember-testing-container {
-  position: absolute;
+  position: fixed;
   background: white;
   bottom: 0;
   right: 0;


### PR DESCRIPTION
I noticed that the testing element wasn't styled properly in the browser. Looks like the CSS isn't added if no options are configured for the addon. Additionally it looks like the positioning of the element needs to be fixed rather than absolute like with qunit.