### PR TITLE
TestCommand.availableOptions invert support

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,22 @@ module.exports = {
 
       if (options.filter) {
         queryString = "grep=" + options.filter;
+
+        if (options.invert) {
+          queryString += '&invert=1';
+        }
       }
 
       return queryString;
     };
+
+    TestCommand.prototype.availableOptions.push({
+      name: 'invert',
+      type: Boolean,
+      default: false,
+      description: 'Invert the filter specified by the --filter argument',
+      aliases: ['i']
+    });
   },
 
   init: function() {


### PR DESCRIPTION
Monkey-patched the TestCommand's availableOptions array to allow for a --invert flag.
This commit allows for invert support, similar to @slindberg 's suggestion in #38 .

It looks like there's [an accepted RFC](https://github.com/davewasmer/rfcs/blob/master/active/0000-extensible-commands.md) to more easily allow for adding commands. However, this is not implemented yet in Ember-CLI and it would be really handy to expose the ability to invert a filter. Since this project already modifies the `TestCommand.prototype`, I think this monkey-patch is reasonable until the ability to do this is baked into Ember-CLI add-on support.