### PR TITLE
Use Ember.Application's container in initializers blueprint

### DIFF
--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -13,8 +13,8 @@ describe('<%= classifiedModuleName %>Initializer', function() {
 
   beforeEach(function() {
     Ember.run(function() {
-      container = new Ember.Container();
       application = Ember.Application.create();
+      container = application.__container__;
       application.deferReadiness();
     });
   });


### PR DESCRIPTION
With current implementation, you end up having two separate containers, and `var container` ends up not really being used anywhere. 

Moreover, in recent versions of ember `new Ember.Container()` results in a deprecation warning:

> A container should only be created for an already instantiated registry. For backward compatibility, an isolated registry will be instantiated just for this container.

[Link to source](https://github.com/emberjs/ember.js/blob/v1.11.3/packages/container/lib/container.js#L24)

Ember CLI has this fixed in https://github.com/ember-cli/ember-cli/commit/818e62bcfa01fe495582e115586d66ebf25ad4ec