### PR TITLE
Rename App to application and move it inside describe

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -9,15 +9,15 @@ import { expect } from 'chai';
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 
-var App;
-
 describe('Acceptance: <%= classifiedModuleName %>', function() {
+  var application;
+  
   beforeEach(function() {
-    App = startApp();
+    application = startApp();
   });
 
   afterEach(function() {
-    Ember.run(App, 'destroy');
+    Ember.run(application, 'destroy');
   });
 
   it('can visit /<%= dasherizedModuleName %>', function() {


### PR DESCRIPTION
To be consistent with https://github.com/ember-cli/ember-cli/blob/master/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js, let's please rename `App` to `application`.

To be consistent with how `container` and `application` are defined in initializer tests blueprint, let's please also move `var application;` inside `describe`.