### PR TITLE
Expose the mocha runner

### DIFF
--- a/vendor/ember-cli-mocha/test-loader.js
+++ b/vendor/ember-cli-mocha/test-loader.js
@@ -24,6 +24,6 @@ jQuery(document).ready(function() {
   setTimeout(function() {
     TestLoader.load();
 
-    mocha.run();
+    window.mochaRunner = mocha.run();
   }, 250);
 });


### PR DESCRIPTION
Access to the mocha runner is required to export test results from addons like ember-cli-sauce

Fixes https://github.com/switchfly/ember-cli-mocha/issues/52

Sadly I couldn't find a better way to transport the runner reference.