### PR TITLE
Loosen broccoli-jshint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/switchfly/ember-cli-mocha",
   "dependencies": {
-    "broccoli-jshint": "0.5.3"
+    "broccoli-jshint": "^0.5.3"
   },
   "bundledDependencies": [ ]
 }


### PR DESCRIPTION
This seem like a generally good idea, and I needed it to get a newer jshint that will stop complaining about certain valid es6.