### PR TITLE
Suppress NPM license warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "authors": [
     "Dan Gebhardt"
   ],
-  "license": "Apache Version 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/switchfly/ember-cli-mocha/issues"
   },


### PR DESCRIPTION
`npm install` was producing this error:

```
npm WARN package.json ember-cli-mocha@0.7.0 license should be a valid SPDX license expression
```

this simple changeset suppresses this warning. 