### PR TITLE
Fix compatibility with Ember CLI 0.2.7

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -8,7 +8,7 @@ module.exports = {
   availableOptions: [
     {
       name: 'test-type',
-      type: ['integration', 'unit'],
+      type: String,
       default: 'integration',
       aliases: [
         { 'i': 'integration'},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-mocha",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Mocha and Chai tests for ember-cli applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I copied the settings from [the QUnit component test](https://github.com/ember-cli/ember-cli/blob/master/blueprints/component-test/index.js#L12) and tested against Ember CLI 1.13.1, but not other versions.

One of my projects uses 0.2.7 (haven't had time to upgrade yet), so this changeset allows working with 0.2.7 and 1.13.x.

I bumped this version to 0.9.1.