### PR TITLE
Remove trailing whitespace from blueprint

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -11,7 +11,7 @@ import startApp from '../helpers/start-app';
 
 describe('Acceptance: <%= classifiedModuleName %>', function() {
   var application;
-  
+
   beforeEach(function() {
     application = startApp();
   });


### PR DESCRIPTION
Removes two empty whitespace characters from generated blueprint for acceptance tests