### PR TITLE
Utilize new destroy-app.js when present.

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.js
@@ -6,8 +6,8 @@ import {
   afterEach
 } from 'mocha';
 import { expect } from 'chai';
-import Ember from 'ember';
 import startApp from '../helpers/start-app';
+<% if (destroyAppExists) { %>import destroyApp from '../helpers/destroy-app';<% } else { %>import Ember from 'ember';<% } %>
 
 describe('Acceptance: <%= classifiedModuleName %>', function() {
   var application;
@@ -17,7 +17,7 @@ describe('Acceptance: <%= classifiedModuleName %>', function() {
   });
 
   afterEach(function() {
-    Ember.run(application, 'destroy');
+    <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>Ember.run(application, 'destroy');<% } %>
   });
 
   it('can visit /<%= dasherizedModuleName %>', function() {

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,3 +1,15 @@
+var existsSync = require('exists-sync');
+var path       = require('path');
+
 module.exports = {
-  description: 'Generates an acceptance test for a feature.'
+  description: 'Generates an acceptance test for a feature.',
+
+  locals: function() {
+    var destroyAppExists =
+      existsSync(path.join(this.project.root, '/tests/helpers/destroy-app.js'));
+
+    return {
+      destroyAppExists: destroyAppExists
+    };
+  }
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/switchfly/ember-cli-mocha",
   "dependencies": {
-    "broccoli-jshint": "^1.1.0"
+    "broccoli-jshint": "^1.1.0",
+    "exists-sync": "0.0.3"
   },
   "bundledDependencies": [ ]
 }


### PR DESCRIPTION
1.13.9 of ember-cli will have a destroy-app.js similar to start-app.js. See [this PR](https://github.com/ember-cli/ember-cli/pull/4772/files).
This patch uses that file if it's present.