### PR TITLE
Upgrade broccoli-jshint to take advantage of broccoli-persistent-filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/switchfly/ember-cli-mocha",
   "dependencies": {
-    "broccoli-jshint": "^0.5.6"
+    "broccoli-jshint": "^1.1.0"
   },
   "bundledDependencies": [ ]
 }


### PR DESCRIPTION
Reduces build time