### PR TITLE
blueprints: Fix typo in afterInstall() method

### DIFF
--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -19,7 +19,7 @@ module.exports = {
       { name: 'ember-cli-test-loader', source: 'ember-cli-test-loader', target: '0.2.2'  }
     ]).then(function() {
       if ('removePackageFromProject' in addonContext) {
-        return addonContext.removePackageFromProject([
+        return addonContext.removePackagesFromProject([
           { name: 'ember-cli-qunit' },
           { name: 'ember-qunit-notifications' }
         ]);


### PR DESCRIPTION
This PR fixes the typo introduced in #97 