### PR TITLE
Revert PR #97

### DIFF
--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -19,10 +19,7 @@ module.exports = {
       { name: 'ember-cli-test-loader', source: 'ember-cli-test-loader', target: '0.2.2'  }
     ]).then(function() {
       if ('removePackageFromProject' in addonContext) {
-        return addonContext.removePackagesFromProject([
-          { name: 'ember-cli-qunit' },
-          { name: 'ember-qunit-notifications' }
-        ]);
+        return addonContext.removePackageFromProject('ember-cli-qunit');
       }
     });
   }


### PR DESCRIPTION
This PR reverts the changes made by #97 since they never even worked in the first place. `ember-qunit-notifications` as of now is a bower dependency which can't be removed via `removePackagesFromProject()`.