### PR TITLE
TestGenerator: Remove "expected false to be truthy" message

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,9 +191,14 @@ module.exports = {
       var output = "describe('" + moduleName + "', function() {\n";
 
       tests.forEach(function(test) {
-        output += "  it('" + test.name + "', function() {\n";
-        output += "    expect(" + test.passed + ", '" + test.errorMessage + "').to.be.ok;\n";
-        output += "  });\n";
+        output +=
+          "  it('" + test.name + "', function() {\n" +
+          "    if (!" + test.passed + ") {\n" +
+          "      var error = new chai.AssertionError('" + test.errorMessage + "');\n" +
+          "      error.stack = undefined;" +
+          "      throw error;\n" +
+          "    }\n" +
+          "  });\n";
       });
 
       output += "});\n";


### PR DESCRIPTION
This PR changes the TestGenerator code to remove the "expected false to be truthy" message that is generated when running `expect(false).to.be.ok;`. The assertion is replaced by manually checking `if (!test.passed)` and then throwing a `new chai.AssertionError` with a truncated stack trace. The stack trace is not helpful at all here because the test files are generated automatically and are not really accessible.