### PR TITLE
Remove JSHint lintTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,6 @@ models, controllers, components, etc. in order to generate the corresponding Moc
 Tests rely on [ember-mocha](https://github.com/switchfly/ember-mocha) modules
 and helpers. Please refer to that project to understand detailed usage.
 
-## Turning off JSHint linting
-
-If you want to turn off JSHint linting you can do the following configuration in your ember-cli-build.js file:
-
-```
-var app = new EmberApp({
-  'babel': {
-    optional: ['es7.decorators']
-  },
-
-  'ember-cli-mocha': {
-    useLintTree: false
-  }
-});
-```
-
 ## Copyright and License
 
 Copyright 2014 Switchfly

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
 
 var path = require('path');
 var fs = require('fs');
-var jshintTrees = require('broccoli-jshint');
 var MergeTrees = require('broccoli-merge-trees');
 var BabelTranspiler = require('broccoli-babel-transpiler');
 var Concat = require('broccoli-concat');
@@ -200,39 +199,5 @@ module.exports = {
 
       return output;
     };
-  },
-
-  lintTree: function(type, tree) {
-    var project = this.project;
-
-    var addonContext = this;
-    var disableLinting = this.options['ember-cli-mocha'] && this.options['ember-cli-mocha'].useLintTree === false;
-    var lintingAddonExists = this.project.addons.filter(function(addon) {
-      return addonContext !== addon && addon.lintTree && addon.isDefaultJSLinter;
-    }).length > 0;
-
-    // Skip if useLintTree === false or another primary linter addon is present
-    if (disableLinting || lintingAddonExists) {
-      // Fakes an empty broccoli tree
-      return { inputTree: tree, rebuild: function() { return []; } };
-    }
-
-    return jshintTrees(tree, {
-      jshintrcPath: this.jshintrc[type],
-      description: 'JSHint ' + type + '- Mocha',
-      testGenerator: function(relativePath, passed, errors) {
-        if (errors) {
-          errors = "\\n" + this.escapeErrorString(errors);
-        } else {
-          errors = "";
-        }
-
-        return project.generateTestFile('JSHint - ' + relativePath, [{
-          name: 'should pass jshint',
-          passed: !!passed,
-          errorMessage: relativePath + ' should pass jshint.' + errors
-        }]);
-      }
-    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "broccoli-babel-transpiler": "^5.5.0",
     "broccoli-concat": "^2.1.0",
     "broccoli-funnel": "^1.0.1",
-    "broccoli-jshint": "^1.1.0",
     "broccoli-merge-trees": "^1.1.1",
     "ember-cli-version-checker": "^1.1.6",
     "ember-mocha": "^0.8.11",


### PR DESCRIPTION
This PR removes the JSHint-based lintTree that has been extracted into the [ember-cli-jshint](https://www.npmjs.com/package/ember-cli-jshint) addon.

This can most-likely be considered a breaking change and should result in a major version bump.

see also https://github.com/ember-cli/ember-cli/pull/5757

/cc @rwjblue 