### PR TITLE
Add destroy step to instance-initializer test blueprint

### DIFF
--- a/blueprints/instance-initializer-test/files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/files/tests/unit/instance-initializers/__name__-test.js
@@ -3,19 +3,26 @@ import { expect } from 'chai';
 import {
   describe,
   it,
-  beforeEach
+  beforeEach,
+  afterEach
 } from 'mocha';
 import Ember from 'ember';
+<% if (destroyAppExists) { %>import destroyApp from '../helpers/destroy-app';<% } %>
 import { initialize } from '<%= dasherizedPackageName %>/instance-initializers/<%= dasherizedModuleName %>';
 
 describe('<%= classifiedModuleName %>InstanceInitializer', function() {
+  let application;
   let appInstance;
 
   beforeEach(function() {
     Ember.run(function() {
-      const application = Ember.Application.create();
+      application = Ember.Application.create();
       appInstance = application.buildInstance();
     });
+  });
+
+  afterEach(function() {
+    <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>Ember.run(application, 'destroy');<% } %>
   });
 
   // Replace this with your real tests.

--- a/blueprints/instance-initializer-test/index.js
+++ b/blueprints/instance-initializer-test/index.js
@@ -1,3 +1,12 @@
 module.exports = {
-  description: 'Generates an instance initializer unit test.'
+  description: 'Generates an instance initializer unit test.',
+
+  locals: function() {
+    var destroyAppExists =
+      existsSync(path.join(this.project.root, '/tests/helpers/destroy-app.js'));
+
+    return {
+      destroyAppExists: destroyAppExists
+    };
+  }
 };


### PR DESCRIPTION
Had multiple instance-initializer tests generated and came across this:

`Assertion Failed: You cannot use the same root element (body) multiple times in an Ember.Application`

Presumably it was because applications were getting created but not destroyed, so implemented a destroy step in the blueprint. That fixed it but if there's a better way please let me know