### PR TITLE
Load Mocha and Chai from NPM

### DIFF
--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -13,7 +13,6 @@ module.exports = {
     var addonContext = this;
 
     return this.addBowerPackagesToProject([
-      { name: 'mocha',                 source: 'mocha',                 target: '~2.2.4' },
       { name: 'chai',                  source: 'chai',                  target: '~2.3.0' },
       { name: 'ember-mocha-adapter',   source: 'ember-mocha-adapter',   target: '~0.3.1' },
       { name: 'ember-cli-test-loader', source: 'ember-cli-test-loader', target: '0.2.2'  }

--- a/blueprints/ember-cli-mocha/index.js
+++ b/blueprints/ember-cli-mocha/index.js
@@ -13,7 +13,6 @@ module.exports = {
     var addonContext = this;
 
     return this.addBowerPackagesToProject([
-      { name: 'chai',                  source: 'chai',                  target: '~2.3.0' },
       { name: 'ember-mocha-adapter',   source: 'ember-mocha-adapter',   target: '~0.3.1' },
       { name: 'ember-cli-test-loader', source: 'ember-cli-test-loader', target: '0.2.2'  }
     ]).then(function() {

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "mocha": "~2.4.5",
     "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1"
   }

--- a/index.js
+++ b/index.js
@@ -103,6 +103,13 @@ module.exports = {
       destDir: '/mocha',
     });
 
+    var chaiPath = path.dirname(resolve.sync('chai'));
+    // var chaiTree = this.treeGenerator(chaiPath);
+    var chaiTree = new Funnel(chaiPath, {
+      files: ['chai.js'],
+      destDir: '/chai',
+    });
+
     var emberMochaBuildSupportPath = path.join(this._emberMochaLibPath, '..', 'build-support');
 
     var mochaSetupTree = new Funnel(emberMochaBuildSupportPath, {
@@ -113,6 +120,7 @@ module.exports = {
     var trees = [
       tree,
       mochaTree,
+      chaiTree,
       mochaSetupTree
     ];
 
@@ -156,7 +164,7 @@ module.exports = {
       var fileAssets = [
         'vendor/mocha/mocha.js',
         'vendor/mocha/mocha.css',
-        app.bowerDirectory + '/chai/chai.js',
+        'vendor/chai/chai.js',
         'vendor/ember-mocha/mocha-setup.js',
         app.bowerDirectory + '/ember-mocha-adapter/adapter.js',
         'vendor/ember-cli-mocha/test-loader.js'

--- a/index.js
+++ b/index.js
@@ -96,6 +96,13 @@ module.exports = {
   },
 
   treeForVendor: function(tree) {
+    var mochaPath = path.dirname(resolve.sync('mocha'));
+    // var mochaTree = this.treeGenerator(mochaPath);
+    var mochaTree = new Funnel(mochaPath, {
+      files: ['mocha.js', 'mocha.css'],
+      destDir: '/mocha',
+    });
+
     var emberMochaBuildSupportPath = path.join(this._emberMochaLibPath, '..', 'build-support');
 
     var mochaSetupTree = new Funnel(emberMochaBuildSupportPath, {
@@ -105,6 +112,7 @@ module.exports = {
 
     var trees = [
       tree,
+      mochaTree,
       mochaSetupTree
     ];
 
@@ -146,8 +154,8 @@ module.exports = {
 
     if (app.tests) {
       var fileAssets = [
-        app.bowerDirectory + '/mocha/mocha.js',
-        app.bowerDirectory + '/mocha/mocha.css',
+        'vendor/mocha/mocha.js',
+        'vendor/mocha/mocha.css',
         app.bowerDirectory + '/chai/chai.js',
         'vendor/ember-mocha/mocha-setup.js',
         app.bowerDirectory + '/ember-mocha-adapter/adapter.js',

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-cli-version-checker": "^1.1.6",
     "ember-mocha": "^0.8.11",
     "exists-sync": "0.0.3",
+    "mocha": "^2.5.3",
     "resolve": "^1.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "broccoli-concat": "^2.1.0",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
+    "chai": "^3.5.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-version-checker": "^1.1.6",
     "ember-mocha": "^0.8.11",


### PR DESCRIPTION
This PR converts Mocha and Chai from Bower into NPM dependencies and updates them at the same time (major version bumps!).

`ember-mocha-adapter` hasn't been converted yet, because:

- it's not published to NPM
- it is supposed to be merged into `ember-mocha` (see [ember-mocha-adapter#35](https://github.com/teddyzeenny/ember-mocha-adapter/issues/35))

/cc @rwjblue 