### PR TITLE
Improved test generator output

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,14 +192,18 @@ module.exports = {
       var output = "describe('" + moduleName + "', function() {\n";
 
       tests.forEach(function(test) {
-        output +=
-          "  it('" + test.name + "', function() {\n" +
-          "    if (!" + test.passed + ") {\n" +
-          "      var error = new chai.AssertionError('" + test.errorMessage + "');\n" +
-          "      error.stack = undefined;" +
-          "      throw error;\n" +
-          "    }\n" +
-          "  });\n";
+        output += "  it('" + test.name + "', function() {\n";
+        if (test.passed) {
+          output +=
+            "    // precompiled test passed\n";
+        } else {
+          output +=
+            "    // precompiled test failed\n" +
+            "    var error = new chai.AssertionError('" + test.errorMessage + "');\n" +
+            "    error.stack = undefined;\n" +
+            "    throw error;\n";
+        }
+        output +=   "  });\n";
       });
 
       output += "});\n";


### PR DESCRIPTION
This PR changes the test generator to evaluate `test.passed` early and output a failing test case only when it is false, otherwise a `// ESLint passed` comment is written.